### PR TITLE
Refine rage mode hook logic

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -1,6 +1,5 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.		*/
-#include <array>
 #include <base/math.h>
 
 #include <engine/client.h>
@@ -28,11 +27,43 @@ static constexpr float DegToRad(float Deg)
         return Deg * pi / 180.0f;
 }
 
+static bool IsFreezeTileIndex(int Tile)
+{
+        return Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE;
+}
+
+static bool IsHookPointOnFreeze(const vec2 &Pos, CCollision *pCollision)
+{
+        if(!pCollision)
+                return false;
+
+        const int Index = pCollision->GetPureMapIndex(Pos);
+        return IsFreezeTileIndex(pCollision->GetTileIndex(Index)) || IsFreezeTileIndex(pCollision->GetFrontTileIndex(Index));
+}
+
+static bool ValidateHookTarget(const CCharacterCore &Core, const vec2 &Target, CCollision *pCollision, float HookLength)
+{
+        if(length(Target) < 0.01f || !pCollision)
+                return false;
+
+        vec2 HookPoint = Target;
+        vec2 Before;
+        const int HitTile = pCollision->IntersectLineTeleHook(Core.m_Pos, Target, &HookPoint, &Before);
+        if(HitTile == 0 || HitTile == TILE_NOHOOK)
+                return false;
+        if(IsFreezeTileIndex(HitTile))
+                return false;
+        if(IsHookPointOnFreeze(HookPoint, pCollision))
+                return false;
+
+        return distance(Core.m_Pos, HookPoint) <= HookLength + 1.0f;
+}
+
 static bool CheckFreeze(const vec2 &Pos, CCollision *pCollision, vec2 *pHit = nullptr)
 {
-	static const vec2 s_aOffsets[] = {
-		vec2(0.0f, 0.0f),
-		vec2(14.0f, 0.0f),
+        static const vec2 s_aOffsets[] = {
+                vec2(0.0f, 0.0f),
+                vec2(14.0f, 0.0f),
 		vec2(-14.0f, 0.0f),
 		vec2(0.0f, 14.0f),
 		vec2(0.0f, -14.0f)};
@@ -70,165 +101,197 @@ static bool PredictFreeze(CCharacterCore Core, const CNetObj_PlayerInput &Input,
 }
 
 static bool TryHookRescue(const CCharacterCore &Core, CNetObj_PlayerInput &Input, const vec2 &HitDir, CCollision *pCollision,
-	float HookLength, bool AllowUnsafe)
+        float HookLength, const vec2 &LastTarget, vec2 *pOutTarget, bool *pOutSafe)
 {
-	if(HookLength <= 0.0f)
-		HookLength = 380.0f;
+        if(HookLength <= 0.0f)
+                HookLength = 380.0f;
 
-	vec2 ThreatDir = HitDir;
-	if(length(ThreatDir) < 0.01f)
-		ThreatDir = vec2(1.0f, 0.0f);
-	else
-		ThreatDir = normalize(ThreatDir);
+        vec2 ThreatDir = HitDir;
+        if(length(ThreatDir) < 0.01f)
+                ThreatDir = vec2(1.0f, 0.0f);
+        else
+                ThreatDir = normalize(ThreatDir);
 
-	vec2 EscapeDir = -ThreatDir;
-	if(length(EscapeDir) < 0.01f)
-		EscapeDir = vec2(-1.0f, 0.0f);
-	const vec2 EscapeNorm = normalize(EscapeDir);
+        vec2 EscapeNorm = -ThreatDir;
+        if(length(EscapeNorm) < 0.01f)
+                EscapeNorm = vec2(-1.0f, 0.0f);
+        else
+                EscapeNorm = normalize(EscapeNorm);
 
-	const vec2 Vel = Core.m_Vel;
-	const float VelLen = length(Vel);
-	vec2 VelNorm = vec2(0.0f, 0.0f);
-	if(VelLen > 0.001f)
-		VelNorm = Vel / VelLen;
+        const vec2 Vel = Core.m_Vel;
+        const float VelLen = length(Vel);
+        vec2 VelNorm = vec2(0.0f, 0.0f);
+        if(VelLen > 0.001f)
+                VelNorm = Vel / VelLen;
 
-	const std::array<float, 17> aAngles = {
-		DegToRad(0.0f),
-		DegToRad(15.0f),
-		-DegToRad(15.0f),
-		DegToRad(30.0f),
-		-DegToRad(30.0f),
-		DegToRad(45.0f),
-		-DegToRad(45.0f),
-		DegToRad(60.0f),
-		-DegToRad(60.0f),
-		DegToRad(75.0f),
-		-DegToRad(75.0f),
-		DegToRad(90.0f),
-		-DegToRad(90.0f),
-		DegToRad(105.0f),
-		-DegToRad(105.0f),
-		DegToRad(120.0f),
-		-DegToRad(120.0f)
-	};
+        const auto Rotate = [](const vec2 &Dir, float Angle) {
+                const float C = std::cos(Angle);
+                const float S = std::sin(Angle);
+                return vec2(Dir.x * C - Dir.y * S, Dir.x * S + Dir.y * C);
+        };
 
-	const auto Rotate = [](const vec2 &Dir, float Angle) {
-		const float C = std::cos(Angle);
-		const float S = std::sin(Angle);
-		return vec2(Dir.x * C - Dir.y * S, Dir.x * S + Dir.y * C);
-	};
+        const CNetObj_PlayerInput BaseInput = Input;
 
-	bool FoundSafe = false;
-	float BestSafeScore = -1e9f;
-	vec2 BestSafeTarget = Core.m_Pos;
+        bool FoundSafe = false;
+        bool FoundFallback = false;
+        float BestSafeScore = -1e9f;
+        float BestFallbackScore = -1e9f;
+        vec2 BestSafeTarget = Core.m_Pos;
+        vec2 BestFallbackTarget = Core.m_Pos;
 
-	float BestAnyScore = -1e9f;
-	vec2 BestAnyTarget = Core.m_Pos;
+        const auto EvaluateDirection = [&](const vec2 &RawDir) {
+                vec2 Dir = RawDir;
+                if(length(Dir) < 0.01f)
+                        return;
+                Dir = normalize(Dir);
 
-	for(float Angle : aAngles)
-	{
-		vec2 Dir = Rotate(EscapeNorm, Angle);
-		if(length(Dir) < 0.001f)
-			continue;
-		Dir = normalize(Dir);
+                vec2 AimPos = Core.m_Pos + Dir * HookLength;
+                vec2 HookPoint = AimPos;
+                bool HasAttach = false;
+                if(pCollision)
+                {
+                        vec2 Before;
+                        const int HitTile = pCollision->IntersectLineTeleHook(Core.m_Pos, AimPos, &HookPoint, &Before);
+                        if(HitTile == 0 || HitTile == TILE_NOHOOK)
+                                return;
+                        if(IsFreezeTileIndex(HitTile))
+                                return;
+                        if(IsHookPointOnFreeze(HookPoint, pCollision))
+                                return;
+                        if(distance(Core.m_Pos, HookPoint) > HookLength + 1.0f)
+                                return;
+                        HasAttach = true;
+                }
 
-		vec2 AimPos = Core.m_Pos + Dir * HookLength;
+                if(!HasAttach)
+                        return;
 
-		vec2 HookPoint = AimPos;
-		bool HasAttach = false;
-		if(pCollision)
-		{
-			vec2 Before;
-			const int HitTile = pCollision->IntersectLineTeleHook(Core.m_Pos, AimPos, &HookPoint, &Before);
-			if(HitTile != 0 && HitTile != TILE_NOHOOK)
-				HasAttach = true;
-		}
+                CNetObj_PlayerInput Test = BaseInput;
+                Test.m_Hook = 1;
+                Test.m_TargetX = (int)HookPoint.x;
+                Test.m_TargetY = (int)HookPoint.y;
 
-		if(!HasAttach && !AllowUnsafe)
-			continue;
+                const bool Safe = !PredictFreeze(Core, Test, pCollision, false, nullptr, g_HookRescuePredictTicks);
 
-		CNetObj_PlayerInput Test = Input;
-		Test.m_Hook = 1;
-		Test.m_TargetX = (int)AimPos.x;
-		Test.m_TargetY = (int)AimPos.y;
+                float Score = dot(Dir, EscapeNorm) * 6.0f;
+                Score -= maximum(dot(Dir, ThreatDir), 0.0f) * 5.0f;
+                Score += clamp(-Dir.y, 0.0f, 1.0f) * 4.0f;
+                Score -= maximum(Dir.y, 0.0f) * 6.0f;
 
-		const bool Safe = HasAttach && !PredictFreeze(Core, Test, pCollision, false, nullptr, g_HookRescuePredictTicks);
+                if(VelLen > 0.001f)
+                        Score += -dot(Dir, VelNorm) * 2.0f;
 
-		float Score = dot(Dir, EscapeNorm) * 3.0f;
-		if(VelLen > 0.001f)
-			Score += -dot(Dir, VelNorm) * 1.5f;
-		if(Vel.y > 1.0f)
-			Score += clamp(-Dir.y, 0.0f, 1.0f) * 3.0f;
+                const float AttachDistance = distance(Core.m_Pos, HookPoint);
+                const float AttachScore = clamp(1.0f - AttachDistance / HookLength, 0.0f, 1.0f);
+                Score += AttachScore * 3.0f;
 
-		const float DownPenalty = Dir.y > 0.0f ? Dir.y : 0.0f;
-		const float DownWeight = Vel.y > 1.0f ? 6.0f : 3.0f;
-		Score -= DownPenalty * DownWeight;
+                if(length(LastTarget) > 0.01f)
+                {
+                        const float Similarity = clamp(1.0f - distance(HookPoint, LastTarget) / 64.0f, -1.0f, 1.0f);
+                        Score += Similarity * 1.5f;
+                }
 
-		if(HasAttach)
-		{
-			const float AttachDistance = distance(Core.m_Pos, HookPoint);
-			const float AttachScore = clamp(1.0f - AttachDistance / HookLength, 0.0f, 1.0f);
-			Score += AttachScore * 2.0f;
-		}
-		else
-			Score -= 3.0f;
+                if(Safe)
+                {
+                        if(!FoundSafe || Score > BestSafeScore)
+                        {
+                                FoundSafe = true;
+                                BestSafeScore = Score;
+                                BestSafeTarget = HookPoint;
+                        }
+                }
+                else
+                {
+                        Score -= 3.0f;
+                        if(!FoundFallback || Score > BestFallbackScore)
+                        {
+                                FoundFallback = true;
+                                BestFallbackScore = Score;
+                                BestFallbackTarget = HookPoint;
+                        }
+                }
+        };
 
-		vec2 CandidateTarget = HasAttach ? HookPoint : AimPos;
+        if(length(LastTarget) > 0.01f)
+                EvaluateDirection(LastTarget - Core.m_Pos);
 
-		if(Safe)
-		{
-			if(Score > BestSafeScore)
-			{
-				BestSafeScore = Score;
-				BestSafeTarget = CandidateTarget;
-				FoundSafe = true;
-			}
-			continue;
-		}
+        const int MaxAngleSteps = 11;
+        for(int Step = 0; Step <= MaxAngleSteps; ++Step)
+        {
+                const float Angle = DegToRad(Step * 15.0f);
+                EvaluateDirection(Rotate(EscapeNorm, Angle));
+                if(Step != 0)
+                        EvaluateDirection(Rotate(EscapeNorm, -Angle));
+        }
 
-		if(AllowUnsafe && HasAttach && Score > BestAnyScore)
-		{
-			BestAnyScore = Score;
-			BestAnyTarget = CandidateTarget;
-		}
-	}
+        vec2 Side = vec2(-EscapeNorm.y, EscapeNorm.x);
+        for(int Step = -4; Step <= 4; ++Step)
+        {
+                const float Angle = DegToRad(Step * 15.0f);
+                EvaluateDirection(Rotate(Side, Angle));
+        }
 
-	if(FoundSafe)
-	{
-		Input.m_Hook = 1;
-		Input.m_TargetX = (int)BestSafeTarget.x;
-		Input.m_TargetY = (int)BestSafeTarget.y;
-		return true;
-	}
+        EvaluateDirection(vec2(0.0f, -1.0f));
+        EvaluateDirection(vec2(-1.0f, -0.4f));
+        EvaluateDirection(vec2(1.0f, -0.4f));
 
-	if(AllowUnsafe && BestAnyScore > -1e8f)
-	{
-		Input.m_Hook = 1;
-		Input.m_TargetX = (int)BestAnyTarget.x;
-		Input.m_TargetY = (int)BestAnyTarget.y;
-		return true;
-	}
+        if(VelLen > 0.001f)
+        {
+                EvaluateDirection(-VelNorm);
+                EvaluateDirection(Rotate(-VelNorm, DegToRad(20.0f)));
+                EvaluateDirection(Rotate(-VelNorm, -DegToRad(20.0f)));
+        }
 
-	return false;
+        if(FoundSafe)
+        {
+                Input.m_Hook = 1;
+                Input.m_TargetX = (int)BestSafeTarget.x;
+                Input.m_TargetY = (int)BestSafeTarget.y;
+                if(pOutTarget)
+                        *pOutTarget = BestSafeTarget;
+                if(pOutSafe)
+                        *pOutSafe = true;
+                return true;
+        }
+
+        if(FoundFallback)
+        {
+                Input.m_Hook = 1;
+                Input.m_TargetX = (int)BestFallbackTarget.x;
+                Input.m_TargetY = (int)BestFallbackTarget.y;
+                if(pOutTarget)
+                        *pOutTarget = BestFallbackTarget;
+                if(pOutSafe)
+                        *pOutSafe = false;
+                return true;
+        }
+
+        return false;
 }
 
 CControls::CControls()
 {
-	mem_zero(&m_aLastData, sizeof(m_aLastData));
-	mem_zero(m_aMousePos, sizeof(m_aMousePos));
-	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
-	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+        mem_zero(&m_aLastData, sizeof(m_aLastData));
+        mem_zero(m_aMousePos, sizeof(m_aMousePos));
+        mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
+        mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+
+        for(int i = 0; i < NUM_DUMMIES; ++i)
+                m_aRageState[i].Reset();
 }
 
 void CControls::OnReset()
 {
-	ResetInput(0);
-	ResetInput(1);
+        ResetInput(0);
+        ResetInput(1);
 
-	for(int &AmmoCount : m_aAmmoCount)
-		AmmoCount = 0;
+        for(int &AmmoCount : m_aAmmoCount)
+                AmmoCount = 0;
 
-	m_LastSendTime = 0;
+        m_LastSendTime = 0;
+
+        for(int i = 0; i < NUM_DUMMIES; ++i)
+                m_aRageState[i].Reset();
 }
 
 void CControls::ResetInput(int Dummy)
@@ -247,8 +310,11 @@ void CControls::ResetInput(int Dummy)
 
 void CControls::OnPlayerDeath()
 {
-	for(int &AmmoCount : m_aAmmoCount)
-		AmmoCount = 0;
+        for(int &AmmoCount : m_aAmmoCount)
+                AmmoCount = 0;
+
+        for(int i = 0; i < NUM_DUMMIES; ++i)
+                m_aRageState[i].Reset();
 }
 
 struct CInputState
@@ -538,25 +604,111 @@ int CControls::SnapInput(int *pData)
                                         HookThreatDir = HitDirShort;
                         }
 
-                        if(GoresMode == 2 && DangerLong)
-                        {
-                                bool ShouldHook = false;
-                                const bool HorizontalThreat = absolute(HookThreatDir.y) <= absolute(HookThreatDir.x);
-                                if(HorizontalThreat)
-                                {
-                                        CNetObj_PlayerInput Future = Input;
-                                        if(PredictFreeze(Core, Future, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
-                                                ShouldHook = true;
-                                }
-                                else if(PredictFreeze(Core, Input, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
-                                        ShouldHook = true;
+                        CRageState &RageState = m_aRageState[g_Config.m_ClDummy];
+                        const float HookLength = m_pClient->m_aTuning[g_Config.m_ClDummy].m_HookLength;
 
-                                if(ShouldHook)
+                        if(GoresMode == 2)
+                        {
+                                if(DangerLong)
                                 {
-                                        float HookLength = m_pClient->m_aTuning[g_Config.m_ClDummy].m_HookLength;
-                                        if(!TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, false))
-                                                TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, true);
+                                        RageState.m_LastThreatDir = HookThreatDir;
+                                        bool ShouldHook = false;
+                                        const bool HorizontalThreat = absolute(HookThreatDir.y) <= absolute(HookThreatDir.x);
+                                        if(HorizontalThreat)
+                                        {
+                                                CNetObj_PlayerInput Future = Input;
+                                                if(PredictFreeze(Core, Future, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
+                                                        ShouldHook = true;
+                                        }
+                                        else if(PredictFreeze(Core, Input, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
+                                                ShouldHook = true;
+
+                                        if(ShouldHook)
+                                        {
+                                                vec2 NewTarget(0.0f, 0.0f);
+                                                bool SafeTarget = false;
+                                                if(TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &NewTarget, &SafeTarget))
+                                                {
+                                                        RageState.m_Active = true;
+                                                        RageState.m_LastTarget = NewTarget;
+                                                        RageState.m_LastThreatDir = HookThreatDir;
+                                                        RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, SafeTarget ? 8 : 4);
+                                                }
+                                        }
                                 }
+
+                                if(RageState.m_Active)
+                                {
+                                        bool KeepHook = DangerLong;
+
+                                        if(!DangerLong)
+                                        {
+                                                if(RageState.m_HoldTicks > 0)
+                                                {
+                                                        RageState.m_HoldTicks--;
+                                                        KeepHook = true;
+                                                }
+                                                else
+                                                {
+                                                        CNetObj_PlayerInput ReleaseTest = Input;
+                                                        ReleaseTest.m_Hook = 0;
+                                                        if(PredictFreeze(Core, ReleaseTest, m_pClient->Collision(), true, nullptr, g_PredictFreezeTicks))
+                                                        {
+                                                                KeepHook = true;
+                                                                RageState.m_HoldTicks = 2;
+                                                        }
+                                                }
+
+                                                if(KeepHook && length(RageState.m_LastThreatDir) > 0.01f)
+                                                {
+                                                        CNetObj_PlayerInput Candidate = Input;
+                                                        vec2 NewTarget(0.0f, 0.0f);
+                                                        bool SafeTarget = false;
+                                                        if(TryHookRescue(Core, Candidate, RageState.m_LastThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &NewTarget, &SafeTarget))
+                                                        {
+                                                                Input = Candidate;
+                                                                RageState.m_LastTarget = NewTarget;
+                                                                if(SafeTarget)
+                                                                        RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 4);
+                                                        }
+                                                }
+                                        }
+                                        else
+                                        {
+                                                RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 4);
+                                        }
+
+                                        if(KeepHook)
+                                        {
+                                                if(!ValidateHookTarget(Core, RageState.m_LastTarget, m_pClient->Collision(), HookLength))
+                                                {
+                                                        RageState.Reset();
+                                                        Input.m_Hook = 0;
+                                                }
+                                                else
+                                                {
+                                                        Input.m_Hook = 1;
+                                                        Input.m_TargetX = (int)RageState.m_LastTarget.x;
+                                                        Input.m_TargetY = (int)RageState.m_LastTarget.y;
+
+                                                        CNetObj_PlayerInput SafetyTest = Input;
+                                                        if(PredictFreeze(Core, SafetyTest, m_pClient->Collision(), false, nullptr, g_PredictFreezeTicks))
+                                                        {
+                                                                RageState.Reset();
+                                                                Input.m_Hook = 0;
+                                                        }
+                                                }
+                                        }
+                                        else
+                                        {
+                                                RageState.Reset();
+                                                Input.m_Hook = 0;
+                                        }
+                                }
+                        }
+                        else
+                        {
+                                RageState.Reset();
                         }
                 }
                 // stress testing

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -83,10 +83,14 @@ static bool CheckFreeze(const vec2 &Pos, CCollision *pCollision, vec2 *pHit = nu
 	return false;
 }
 
-static bool PredictFreeze(CCharacterCore Core, const CNetObj_PlayerInput &Input, CCollision *pCollision, bool CheckStart = true, vec2 *pHit = nullptr, int Steps = g_PredictFreezeTicks)
+static bool PredictFreeze(CCharacterCore Core, const CNetObj_PlayerInput &Input, CCollision *pCollision, bool CheckStart = true, vec2 *pHit = nullptr, int Steps = g_PredictFreezeTicks, vec2 *pFinalPos = nullptr)
 {
 	if(CheckStart && CheckFreeze(Core.m_Pos, pCollision, pHit))
+	{
+		if(pFinalPos)
+			*pFinalPos = Core.m_Pos;
 		return true;
+	}
 
 	for(int i = 0; i < Steps; i++)
 	{
@@ -95,179 +99,199 @@ static bool PredictFreeze(CCharacterCore Core, const CNetObj_PlayerInput &Input,
 		Core.Move();
 		Core.Quantize();
 		if(CheckFreeze(Core.m_Pos, pCollision, pHit))
+		{
+			if(pFinalPos)
+				*pFinalPos = Core.m_Pos;
 			return true;
+		}
 	}
+	if(pFinalPos)
+		*pFinalPos = Core.m_Pos;
 	return false;
 }
 
-static bool TryHookRescue(const CCharacterCore &Core, CNetObj_PlayerInput &Input, const vec2 &HitDir, CCollision *pCollision,
-        float HookLength, const vec2 &LastTarget, vec2 *pOutTarget, bool *pOutSafe)
+static bool TryHookRescue(const CCharacterCore &Core, const CNetObj_PlayerInput &Input, const vec2 &HitDir, CCollision *pCollision,
+	float HookLength, const vec2 &LastTarget, vec2 *pOutTarget, bool *pOutSafe, float *pOutScore = nullptr)
 {
-        if(HookLength <= 0.0f)
-                HookLength = 380.0f;
+	if(HookLength <= 0.0f)
+		HookLength = 380.0f;
 
-        vec2 ThreatDir = HitDir;
-        if(length(ThreatDir) < 0.01f)
-                ThreatDir = vec2(1.0f, 0.0f);
-        else
-                ThreatDir = normalize(ThreatDir);
+	vec2 ThreatDir = HitDir;
+	if(length(ThreatDir) < 0.01f)
+		ThreatDir = vec2(1.0f, 0.0f);
+	else
+		ThreatDir = normalize(ThreatDir);
 
-        vec2 EscapeNorm = -ThreatDir;
-        if(length(EscapeNorm) < 0.01f)
-                EscapeNorm = vec2(-1.0f, 0.0f);
-        else
-                EscapeNorm = normalize(EscapeNorm);
+	vec2 EscapeDir = -ThreatDir;
+	if(length(EscapeDir) < 0.01f)
+		EscapeDir = vec2(-1.0f, 0.0f);
+	else
+		EscapeDir = normalize(EscapeDir);
 
-        const vec2 Vel = Core.m_Vel;
-        const float VelLen = length(Vel);
-        vec2 VelNorm = vec2(0.0f, 0.0f);
-        if(VelLen > 0.001f)
-                VelNorm = Vel / VelLen;
+	const auto Rotate = [](const vec2 &Dir, float Angle) {
+		const float C = std::cos(Angle);
+		const float S = std::sin(Angle);
+		return vec2(Dir.x * C - Dir.y * S, Dir.x * S + Dir.y * C);
+	};
 
-        const auto Rotate = [](const vec2 &Dir, float Angle) {
-                const float C = std::cos(Angle);
-                const float S = std::sin(Angle);
-                return vec2(Dir.x * C - Dir.y * S, Dir.x * S + Dir.y * C);
-        };
+	float BestScore = -1e9f;
+	vec2 BestTarget = Core.m_Pos;
+	bool BestSafe = false;
+	bool Found = false;
 
-        const CNetObj_PlayerInput BaseInput = Input;
+	auto EvaluateDirection = [&](const vec2 &RawDir, float Bias = 0.0f) {
+		vec2 Dir = RawDir;
+		if(length(Dir) < 0.01f)
+			return;
+		Dir = normalize(Dir);
 
-        bool FoundSafe = false;
-        bool FoundFallback = false;
-        float BestSafeScore = -1e9f;
-        float BestFallbackScore = -1e9f;
-        vec2 BestSafeTarget = Core.m_Pos;
-        vec2 BestFallbackTarget = Core.m_Pos;
+		vec2 AimPos = Core.m_Pos + Dir * HookLength;
+		vec2 HookPoint = AimPos;
+		if(pCollision)
+		{
+			vec2 Before;
+			const int HitTile = pCollision->IntersectLineTeleHook(Core.m_Pos, AimPos, &HookPoint, &Before);
+			if(HitTile == 0 || HitTile == TILE_NOHOOK)
+				return;
+			if(IsFreezeTileIndex(HitTile))
+				return;
+			if(IsHookPointOnFreeze(HookPoint, pCollision))
+				return;
+			if(distance(Core.m_Pos, HookPoint) > HookLength + 1.0f)
+				return;
+		}
 
-        const auto EvaluateDirection = [&](const vec2 &RawDir) {
-                vec2 Dir = RawDir;
-                if(length(Dir) < 0.01f)
-                        return;
-                Dir = normalize(Dir);
+		vec2 AttachDir = HookPoint - Core.m_Pos;
+		if(length(AttachDir) < 1.0f)
+			return;
+		vec2 AttachNorm = normalize(AttachDir);
 
-                vec2 AimPos = Core.m_Pos + Dir * HookLength;
-                vec2 HookPoint = AimPos;
-                bool HasAttach = false;
-                if(pCollision)
-                {
-                        vec2 Before;
-                        const int HitTile = pCollision->IntersectLineTeleHook(Core.m_Pos, AimPos, &HookPoint, &Before);
-                        if(HitTile == 0 || HitTile == TILE_NOHOOK)
-                                return;
-                        if(IsFreezeTileIndex(HitTile))
-                                return;
-                        if(IsHookPointOnFreeze(HookPoint, pCollision))
-                                return;
-                        if(distance(Core.m_Pos, HookPoint) > HookLength + 1.0f)
-                                return;
-                        HasAttach = true;
-                }
+		const float AlignEscape = dot(AttachNorm, EscapeDir);
+		const float AlignThreat = dot(AttachNorm, ThreatDir);
 
-                if(!HasAttach)
-                        return;
+		if(HookPoint.y > Core.m_Pos.y + 48.0f && AlignEscape < 0.45f)
+			return;
 
-                CNetObj_PlayerInput Test = BaseInput;
-                Test.m_Hook = 1;
-                Test.m_TargetX = (int)HookPoint.x;
-                Test.m_TargetY = (int)HookPoint.y;
+		CNetObj_PlayerInput Candidate = Input;
+		Candidate.m_Hook = 1;
+		Candidate.m_TargetX = (int)HookPoint.x;
+		Candidate.m_TargetY = (int)HookPoint.y;
 
-                const bool Safe = !PredictFreeze(Core, Test, pCollision, false, nullptr, g_HookRescuePredictTicks);
+		vec2 FinalPos = Core.m_Pos;
+		const bool HitsFreeze = PredictFreeze(Core, Candidate, pCollision, false, nullptr, g_HookRescuePredictTicks, &FinalPos);
+		const bool Safe = !HitsFreeze;
 
-                float Score = dot(Dir, EscapeNorm) * 6.0f;
-                Score -= maximum(dot(Dir, ThreatDir), 0.0f) * 5.0f;
-                Score += clamp(-Dir.y, 0.0f, 1.0f) * 4.0f;
-                Score -= maximum(Dir.y, 0.0f) * 6.0f;
+		float Score = Bias;
+		Score += AlignEscape * 11.0f;
+		if(AlignEscape < 0.0f)
+			Score += AlignEscape * 4.0f;
 
-                if(VelLen > 0.001f)
-                        Score += -dot(Dir, VelNorm) * 2.0f;
+		Score -= maximum(AlignThreat, 0.0f) * 18.0f;
+		if(AlignThreat > 0.35f)
+			Score -= (AlignThreat - 0.35f) * 20.0f;
 
-                const float AttachDistance = distance(Core.m_Pos, HookPoint);
-                const float AttachScore = clamp(1.0f - AttachDistance / HookLength, 0.0f, 1.0f);
-                Score += AttachScore * 3.0f;
+		if(AttachNorm.y < 0.0f)
+			Score += clamp(-AttachNorm.y, 0.0f, 1.0f) * 6.0f;
+		else
+			Score -= clamp(AttachNorm.y, 0.0f, 1.0f) * 14.0f;
 
-                if(length(LastTarget) > 0.01f)
-                {
-                        const float Similarity = clamp(1.0f - distance(HookPoint, LastTarget) / 64.0f, -1.0f, 1.0f);
-                        Score += Similarity * 1.5f;
-                }
+		const float HeightDelta = Core.m_Pos.y - HookPoint.y;
+		Score += clamp(HeightDelta / 64.0f, -1.5f, 1.5f) * 4.5f;
 
-                if(Safe)
-                {
-                        if(!FoundSafe || Score > BestSafeScore)
-                        {
-                                FoundSafe = true;
-                                BestSafeScore = Score;
-                                BestSafeTarget = HookPoint;
-                        }
-                }
-                else
-                {
-                        Score -= 3.0f;
-                        if(!FoundFallback || Score > BestFallbackScore)
-                        {
-                                FoundFallback = true;
-                                BestFallbackScore = Score;
-                                BestFallbackTarget = HookPoint;
-                        }
-                }
-        };
+		const float AttachDistance = distance(Core.m_Pos, HookPoint);
+		Score += clamp(1.0f - AttachDistance / HookLength, 0.0f, 1.0f) * 3.0f;
 
-        if(length(LastTarget) > 0.01f)
-                EvaluateDirection(LastTarget - Core.m_Pos);
+		if(length(LastTarget) > 0.01f)
+		{
+			const float Similarity = clamp(1.0f - distance(HookPoint, LastTarget) / 48.0f, -1.0f, 1.0f);
+			Score += Similarity * 1.8f;
+		}
 
-        const int MaxAngleSteps = 11;
-        for(int Step = 0; Step <= MaxAngleSteps; ++Step)
-        {
-                const float Angle = DegToRad(Step * 15.0f);
-                EvaluateDirection(Rotate(EscapeNorm, Angle));
-                if(Step != 0)
-                        EvaluateDirection(Rotate(EscapeNorm, -Angle));
-        }
+		if(Safe)
+		{
+			Score += 5.0f;
+			const vec2 EscapeDelta = FinalPos - Core.m_Pos;
+			const float EscapeProgress = dot(EscapeDelta, EscapeDir);
+			Score += clamp(EscapeProgress / 96.0f, -1.5f, 1.5f) * 5.5f;
 
-        vec2 Side = vec2(-EscapeNorm.y, EscapeNorm.x);
-        for(int Step = -4; Step <= 4; ++Step)
-        {
-                const float Angle = DegToRad(Step * 15.0f);
-                EvaluateDirection(Rotate(Side, Angle));
-        }
+			const float HeightGain = Core.m_Pos.y - FinalPos.y;
+			Score += clamp(HeightGain / 72.0f, -1.0f, 1.0f) * 3.0f;
+		}
+		else
+		{
+			Score -= 12.0f;
+			if(AlignEscape < 0.25f)
+				return;
+		}
 
-        EvaluateDirection(vec2(0.0f, -1.0f));
-        EvaluateDirection(vec2(-1.0f, -0.4f));
-        EvaluateDirection(vec2(1.0f, -0.4f));
+		if(AttachNorm.y > 0.4f)
+			Score -= (AttachNorm.y - 0.4f) * 45.0f;
 
-        if(VelLen > 0.001f)
-        {
-                EvaluateDirection(-VelNorm);
-                EvaluateDirection(Rotate(-VelNorm, DegToRad(20.0f)));
-                EvaluateDirection(Rotate(-VelNorm, -DegToRad(20.0f)));
-        }
+		if(!Found || Score > BestScore)
+		{
+			Found = true;
+			BestScore = Score;
+			BestTarget = HookPoint;
+			BestSafe = Safe;
+		}
+	};
 
-        if(FoundSafe)
-        {
-                Input.m_Hook = 1;
-                Input.m_TargetX = (int)BestSafeTarget.x;
-                Input.m_TargetY = (int)BestSafeTarget.y;
-                if(pOutTarget)
-                        *pOutTarget = BestSafeTarget;
-                if(pOutSafe)
-                        *pOutSafe = true;
-                return true;
-        }
+	if(length(LastTarget) > 0.01f)
+	{
+		const vec2 LastDir = LastTarget - Core.m_Pos;
+		if(length(LastDir) > 1.0f)
+		{
+			const vec2 LastNorm = normalize(LastDir);
+			if(dot(LastNorm, EscapeDir) > 0.1f)
+				EvaluateDirection(LastDir, 2.5f);
+		}
+	}
 
-        if(FoundFallback)
-        {
-                Input.m_Hook = 1;
-                Input.m_TargetX = (int)BestFallbackTarget.x;
-                Input.m_TargetY = (int)BestFallbackTarget.y;
-                if(pOutTarget)
-                        *pOutTarget = BestFallbackTarget;
-                if(pOutSafe)
-                        *pOutSafe = false;
-                return true;
-        }
+	EvaluateDirection(EscapeDir, 3.0f);
 
-        return false;
+	const int MaxAngleSteps = 8;
+	for(int Step = 1; Step <= MaxAngleSteps; ++Step)
+	{
+		const float Angle = DegToRad(Step * 12.0f);
+		EvaluateDirection(Rotate(EscapeDir, Angle));
+		EvaluateDirection(Rotate(EscapeDir, -Angle));
+	}
+
+	vec2 SideDir = vec2(-EscapeDir.y, EscapeDir.x);
+	for(int Step = -3; Step <= 3; ++Step)
+	{
+		const float Angle = DegToRad(Step * 15.0f);
+		EvaluateDirection(Rotate(SideDir, Angle));
+	}
+
+	EvaluateDirection(vec2(0.0f, -1.0f), 1.5f);
+	EvaluateDirection(vec2(-1.0f, -0.4f));
+	EvaluateDirection(vec2(1.0f, -0.4f));
+
+	if(length(Core.m_Vel) > 0.01f)
+	{
+		vec2 VelNorm = normalize(Core.m_Vel);
+		EvaluateDirection(-VelNorm, 0.5f);
+		EvaluateDirection(Rotate(-VelNorm, DegToRad(20.0f)));
+		EvaluateDirection(Rotate(-VelNorm, -DegToRad(20.0f)));
+	}
+
+	if(!Found)
+		return false;
+
+	const float ScoreThreshold = -0.5f;
+	if(BestScore < ScoreThreshold)
+		return false;
+
+	if(pOutTarget)
+		*pOutTarget = BestTarget;
+	if(pOutSafe)
+		*pOutSafe = BestSafe;
+	if(pOutScore)
+		*pOutScore = BestScore;
+	return true;
 }
+
 
 CControls::CControls()
 {
@@ -604,112 +628,154 @@ int CControls::SnapInput(int *pData)
                                         HookThreatDir = HitDirShort;
                         }
 
-                        CRageState &RageState = m_aRageState[g_Config.m_ClDummy];
-                        const float HookLength = m_pClient->m_aTuning[g_Config.m_ClDummy].m_HookLength;
+				CRageState &RageState = m_aRageState[g_Config.m_ClDummy];
+				const float HookLength = m_pClient->m_aTuning[g_Config.m_ClDummy].m_HookLength;
 
-                        if(GoresMode == 2)
-                        {
-                                if(DangerLong)
-                                {
-                                        RageState.m_LastThreatDir = HookThreatDir;
-                                        bool ShouldHook = false;
-                                        const bool HorizontalThreat = absolute(HookThreatDir.y) <= absolute(HookThreatDir.x);
-                                        if(HorizontalThreat)
-                                        {
-                                                CNetObj_PlayerInput Future = Input;
-                                                if(PredictFreeze(Core, Future, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
-                                                        ShouldHook = true;
-                                        }
-                                        else if(PredictFreeze(Core, Input, m_pClient->Collision(), false, nullptr, g_HookRescuePredictTicks))
-                                                ShouldHook = true;
+				if(GoresMode == 2)
+				{
+					const bool DangerActive = DangerLong;
+					if(DangerActive)
+					{
+						RageState.m_LastThreatDir = HookThreatDir;
+						vec2 NewTarget(0.0f, 0.0f);
+						bool SafeTarget = false;
+						float TargetScore = 0.0f;
+						if(TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &NewTarget, &SafeTarget, &TargetScore))
+						{
+							RageState.m_Active = true;
+							RageState.m_LastTarget = NewTarget;
+							RageState.m_LastThreatDir = HookThreatDir;
+							RageState.m_LastSafe = SafeTarget;
+							RageState.m_LastScore = TargetScore;
+							RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, SafeTarget ? 14 : 9);
+						}
+					}
 
-                                        if(ShouldHook)
-                                        {
-                                                vec2 NewTarget(0.0f, 0.0f);
-                                                bool SafeTarget = false;
-                                                if(TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &NewTarget, &SafeTarget))
-                                                {
-                                                        RageState.m_Active = true;
-                                                        RageState.m_LastTarget = NewTarget;
-                                                        RageState.m_LastThreatDir = HookThreatDir;
-                                                        RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, SafeTarget ? 8 : 4);
-                                                }
-                                        }
-                                }
+					bool KeepHook = RageState.m_Active;
 
-                                if(RageState.m_Active)
-                                {
-                                        bool KeepHook = DangerLong;
+					if(KeepHook)
+					{
+						if(!ValidateHookTarget(Core, RageState.m_LastTarget, m_pClient->Collision(), HookLength))
+							KeepHook = false;
+					}
 
-                                        if(!DangerLong)
-                                        {
-                                                if(RageState.m_HoldTicks > 0)
-                                                {
-                                                        RageState.m_HoldTicks--;
-                                                        KeepHook = true;
-                                                }
-                                                else
-                                                {
-                                                        CNetObj_PlayerInput ReleaseTest = Input;
-                                                        ReleaseTest.m_Hook = 0;
-                                                        if(PredictFreeze(Core, ReleaseTest, m_pClient->Collision(), true, nullptr, g_PredictFreezeTicks))
-                                                        {
-                                                                KeepHook = true;
-                                                                RageState.m_HoldTicks = 2;
-                                                        }
-                                                }
+					if(KeepHook && RageState.m_LastTarget.y > Core.m_Pos.y + 48.0f)
+					{
+						vec2 Adjusted(0.0f, 0.0f);
+						bool AdjustedSafe = false;
+						float AdjustedScore = 0.0f;
+						if(TryHookRescue(Core, Input, RageState.m_LastThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &Adjusted, &AdjustedSafe, &AdjustedScore))
+						{
+							RageState.m_LastTarget = Adjusted;
+							RageState.m_LastSafe = AdjustedSafe;
+							RageState.m_LastScore = AdjustedScore;
+							if(AdjustedSafe)
+								RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 10);
+						}
+						else
+						{
+							KeepHook = false;
+						}
+					}
 
-                                                if(KeepHook && length(RageState.m_LastThreatDir) > 0.01f)
-                                                {
-                                                        CNetObj_PlayerInput Candidate = Input;
-                                                        vec2 NewTarget(0.0f, 0.0f);
-                                                        bool SafeTarget = false;
-                                                        if(TryHookRescue(Core, Candidate, RageState.m_LastThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &NewTarget, &SafeTarget))
-                                                        {
-                                                                Input = Candidate;
-                                                                RageState.m_LastTarget = NewTarget;
-                                                                if(SafeTarget)
-                                                                        RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 4);
-                                                        }
-                                                }
-                                        }
-                                        else
-                                        {
-                                                RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 4);
-                                        }
+					if(KeepHook && DangerActive)
+					{
+						vec2 LastDir = RageState.m_LastTarget - Core.m_Pos;
+						if(length(LastDir) > 0.01f && length(HookThreatDir) > 0.01f)
+						{
+							vec2 LastNorm = normalize(LastDir);
+							vec2 ThreatNorm = normalize(HookThreatDir);
+							if(dot(LastNorm, ThreatNorm) > -0.15f)
+							{
+								vec2 Adjusted(0.0f, 0.0f);
+								bool AdjustedSafe = false;
+								float AdjustedScore = 0.0f;
+								if(TryHookRescue(Core, Input, HookThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &Adjusted, &AdjustedSafe, &AdjustedScore))
+								{
+									RageState.m_LastTarget = Adjusted;
+									RageState.m_LastSafe = AdjustedSafe;
+									RageState.m_LastScore = AdjustedScore;
+									if(AdjustedSafe)
+										RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 12);
+								}
+								else
+								{
+									KeepHook = false;
+								}
+							}
+						}
+						else if(length(HookThreatDir) > 0.01f)
+						{
+							RageState.m_LastThreatDir = HookThreatDir;
+						}
+					}
 
-                                        if(KeepHook)
-                                        {
-                                                if(!ValidateHookTarget(Core, RageState.m_LastTarget, m_pClient->Collision(), HookLength))
-                                                {
-                                                        RageState.Reset();
-                                                        Input.m_Hook = 0;
-                                                }
-                                                else
-                                                {
-                                                        Input.m_Hook = 1;
-                                                        Input.m_TargetX = (int)RageState.m_LastTarget.x;
-                                                        Input.m_TargetY = (int)RageState.m_LastTarget.y;
+					if(KeepHook && !DangerActive)
+					{
+						if(RageState.m_HoldTicks > 0)
+						{
+							RageState.m_HoldTicks--;
+						}
+						else
+						{
+							CNetObj_PlayerInput ReleaseTest = Input;
+							ReleaseTest.m_Hook = 0;
+							if(!PredictFreeze(Core, ReleaseTest, m_pClient->Collision(), true, nullptr, g_PredictFreezeTicks))
+							{
+								KeepHook = false;
+							}
+							else
+							{
+								RageState.m_HoldTicks = 3;
+							}
+						}
 
-                                                        CNetObj_PlayerInput SafetyTest = Input;
-                                                        if(PredictFreeze(Core, SafetyTest, m_pClient->Collision(), false, nullptr, g_PredictFreezeTicks))
-                                                        {
-                                                                RageState.Reset();
-                                                                Input.m_Hook = 0;
-                                                        }
-                                                }
-                                        }
-                                        else
-                                        {
-                                                RageState.Reset();
-                                                Input.m_Hook = 0;
-                                        }
-                                }
-                        }
-                        else
-                        {
-                                RageState.Reset();
-                        }
+						if(KeepHook && length(RageState.m_LastThreatDir) > 0.01f)
+						{
+							vec2 Adjusted(0.0f, 0.0f);
+							bool AdjustedSafe = false;
+							float AdjustedScore = 0.0f;
+							if(TryHookRescue(Core, Input, RageState.m_LastThreatDir, m_pClient->Collision(), HookLength, RageState.m_LastTarget, &Adjusted, &AdjustedSafe, &AdjustedScore))
+							{
+								RageState.m_LastTarget = Adjusted;
+								RageState.m_LastSafe = AdjustedSafe;
+								RageState.m_LastScore = AdjustedScore;
+								if(AdjustedSafe)
+									RageState.m_HoldTicks = maximum(RageState.m_HoldTicks, 4);
+							}
+						}
+					}
+
+					if(KeepHook)
+					{
+						CNetObj_PlayerInput HookInput = Input;
+						HookInput.m_Hook = 1;
+						HookInput.m_TargetX = (int)RageState.m_LastTarget.x;
+						HookInput.m_TargetY = (int)RageState.m_LastTarget.y;
+
+						if(PredictFreeze(Core, HookInput, m_pClient->Collision(), false, nullptr, g_PredictFreezeTicks))
+						{
+							KeepHook = false;
+						}
+						else
+						{
+							Input.m_Hook = 1;
+							Input.m_TargetX = HookInput.m_TargetX;
+							Input.m_TargetY = HookInput.m_TargetY;
+						}
+					}
+
+					if(!KeepHook)
+					{
+						RageState.Reset();
+						Input.m_Hook = 0;
+					}
+				}
+				else
+				{
+					RageState.Reset();
+				}
+
                 }
                 // stress testing
 #ifdef CONF_DEBUG

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -16,11 +16,29 @@ public:
 	float GetMinMouseDistance() const;
 	float GetMaxMouseDistance() const;
 
-	vec2 m_aMousePos[NUM_DUMMIES];
-	vec2 m_aMousePosOnAction[NUM_DUMMIES];
-	vec2 m_aTargetPos[NUM_DUMMIES];
+        vec2 m_aMousePos[NUM_DUMMIES];
+        vec2 m_aMousePosOnAction[NUM_DUMMIES];
+        vec2 m_aTargetPos[NUM_DUMMIES];
 
-	int m_aAmmoCount[NUM_WEAPONS];
+        struct CRageState
+        {
+                bool m_Active;
+                int m_HoldTicks;
+                vec2 m_LastTarget;
+                vec2 m_LastThreatDir;
+
+                void Reset()
+                {
+                        m_Active = false;
+                        m_HoldTicks = 0;
+                        m_LastTarget = vec2(0.0f, 0.0f);
+                        m_LastThreatDir = vec2(0.0f, 0.0f);
+                }
+        };
+
+        CRageState m_aRageState[NUM_DUMMIES];
+
+        int m_aAmmoCount[NUM_WEAPONS];
 
 	int64_t m_LastSendTime;
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -20,21 +20,25 @@ public:
         vec2 m_aMousePosOnAction[NUM_DUMMIES];
         vec2 m_aTargetPos[NUM_DUMMIES];
 
-        struct CRageState
-        {
-                bool m_Active;
-                int m_HoldTicks;
-                vec2 m_LastTarget;
-                vec2 m_LastThreatDir;
+	struct CRageState
+	{
+		bool m_Active;
+		int m_HoldTicks;
+		vec2 m_LastTarget;
+		vec2 m_LastThreatDir;
+		bool m_LastSafe;
+		float m_LastScore;
 
-                void Reset()
-                {
-                        m_Active = false;
-                        m_HoldTicks = 0;
-                        m_LastTarget = vec2(0.0f, 0.0f);
-                        m_LastThreatDir = vec2(0.0f, 0.0f);
-                }
-        };
+		void Reset()
+		{
+			m_Active = false;
+			m_HoldTicks = 0;
+			m_LastTarget = vec2(0.0f, 0.0f);
+			m_LastThreatDir = vec2(0.0f, 0.0f);
+			m_LastSafe = false;
+			m_LastScore = 0.0f;
+		}
+	};
 
         CRageState m_aRageState[NUM_DUMMIES];
 


### PR DESCRIPTION
## Summary
- add persistent rage-bot state tracking so the client can coordinate automatic hook usage across ticks
- rewrite the rage rescue evaluation to score safe hook targets while avoiding freeze tiles and preferring upward, opposite escape vectors
- ensure resets clear rage state and release the hook safely when danger passes or a target becomes unsafe

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVULKAN=OFF *(fails: missing Ogg/Opus/Opusfile/SDL2 development packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b5da63e8832ca15f975478f1325a